### PR TITLE
fixes ::populate() must be of the type array, null given

### DIFF
--- a/src/REST/Base/Nebucord_RESTHTTPClient.php
+++ b/src/REST/Base/Nebucord_RESTHTTPClient.php
@@ -150,10 +150,10 @@ class Nebucord_RESTHTTPClient extends Nebucord_RESTBase_Abstract {
      * @see Nebucord_RESTBase_Abstract::parseResponse()
      *
      * @param string $response
-     * @return array|null
+     * @return array
      */
     protected function parseResponse($response) {
-        $res = null;
+        $res = [];
         $res_ar = explode("\r\n\r\n", $response);
         if(strpos($res_ar[0], "200 OK") !== false) {
             $r = trim(substr($res_ar[1], 4, -3));
@@ -167,7 +167,7 @@ class Nebucord_RESTHTTPClient extends Nebucord_RESTBase_Abstract {
      *
      * @see Nebucord_RESTBase_Abstract::execute()
      *
-     * @return array|null
+     * @return array
      */
     public function execute() {
         $this->connect();
@@ -175,6 +175,6 @@ class Nebucord_RESTHTTPClient extends Nebucord_RESTBase_Abstract {
         if($bytes > 0) {
             return $this->receive();
         }
-        return null;
+        return [];
     }
 }


### PR DESCRIPTION
response from parseResponse and execute is always used as array, ther…efore never return NULL. it will cause:

Nebucord\Base\Nebucord_Model_Abstract::populate() must be of the type array, null given